### PR TITLE
refactor(jobs): use ubuntu-20.04 as the default vmImage

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Parameters:
   Useful when your `pre-commit-config.yaml` file contains [`local hooks`].
   Optional. See: [Temporarily disabling hooks](https://pre-commit.com/#temporarily-disabling-hooks).
 - `vmImage` (`string`): Name of the VM Image to use for running the pipeline.
-  Defaults to [`ubuntu-latest`].  Options: ([`ubuntu-20.04`], [`ubuntu-22.04`],
+  Defaults to [`ubuntu-20.04`].  Options: ([`ubuntu-20.04`], [`ubuntu-22.04`],
   [`ubuntu-latest`]).
 
 Example:
@@ -60,7 +60,7 @@ Parameters:
   publishing the package. Defaults to `"3.11"`. Optional. Options: (`"2.7"`,
   and `"3.6"` through `"3.11"`)
 - `vmImage` (`string`): Name of the VM Image to use for running the pipeline.
-  Defaults to [`ubuntu-latest`]. Optional. Options: ([`ubuntu-20.04`],
+  Defaults to [`ubuntu-20.04`]. Optional. Options: ([`ubuntu-20.04`],
   [`ubuntu-22.04`], [`ubuntu-latest`]).
 
 Example:
@@ -91,7 +91,7 @@ Parameters:
   publishing the package. Defaults to `"3.11"`. Optional. Options: (`"2.7"`,
   and `"3.6"` through `"3.11"`)
 - `vmImage` (`string`): Name of the VM Image to use for running the pipeline.
-  Defaults to [`ubuntu-latest`]. Optional. Options: ([`ubuntu-20.04`],
+  Defaults to [`ubuntu-20.04`]. Optional. Options: ([`ubuntu-20.04`],
   [`ubuntu-22.04`], [`ubuntu-latest`]).
 
 Example:

--- a/jobs/pre-commit.yml
+++ b/jobs/pre-commit.yml
@@ -18,7 +18,7 @@ parameters:
     default: ""
   - name: vmImage
     type: string
-    default: "ubuntu-latest"
+    default: "ubuntu-20.04"
     values:
       - "ubuntu-20.04"
       - "ubuntu-22.04"

--- a/jobs/publish-python-package-artifacts.yml
+++ b/jobs/publish-python-package-artifacts.yml
@@ -19,14 +19,14 @@ parameters:
       - "3.11"
   - name: vmImage
     type: string
-    default: "ubuntu-latest"
+    default: "ubuntu-20.04"
     values:
       - "ubuntu-20.04"
       - "ubuntu-22.04"
       - "ubuntu-latest"
 
 jobs:
-  - job: Publish
+  - job: publish
 
     pool:
       vmImage: ${{ parameters.vmImage }}

--- a/jobs/tox.yml
+++ b/jobs/tox.yml
@@ -18,7 +18,7 @@ parameters:
       - "3.11"
   - name: vmImage
     type: string
-    default: "ubuntu-latest"
+    default: "ubuntu-20.04"
     values:
       - "ubuntu-20.04"
       - "ubuntu-22.04"


### PR DESCRIPTION
this will allow our users to run Python 2.7 through 3.11